### PR TITLE
Validate extension scripts and stylesheets as URLs

### DIFF
--- a/pkg/apis/webconsole/util/helpers.go
+++ b/pkg/apis/webconsole/util/helpers.go
@@ -17,15 +17,5 @@ func GetWebConsoleFileReferences(config *v1.WebConsoleConfiguration) []*string {
 		refs = append(refs, &config.ServingInfo.NamedCertificates[i].KeyFile)
 	}
 
-	for i := range config.ExtensionScripts {
-		refs = append(refs, &config.ExtensionScripts[i])
-	}
-	for i := range config.ExtensionStylesheets {
-		refs = append(refs, &config.ExtensionStylesheets[i])
-	}
-	for i := range config.Extensions {
-		refs = append(refs, &config.Extensions[i].SourceDirectory)
-	}
-
 	return refs
 }


### PR DESCRIPTION
Also remove validation of obsolete extensions directories array, which is no longer used.

The extension property names will be updated in a follow-on.

/assign @jwforres 
/cc @deads2k 