### PR TITLE
Add console version to config.js

### DIFF
--- a/pkg/assets/apiserver/asset_apiserver.go
+++ b/pkg/assets/apiserver/asset_apiserver.go
@@ -252,6 +252,7 @@ func (c *completedConfig) addWebConsoleConfig(serverMux *genericmux.PathRecorder
 	versionInfo := assets.WebConsoleVersion{
 		KubernetesVersion: c.ExtraConfig.KubeVersion,
 		OpenShiftVersion:  c.ExtraConfig.OpenShiftVersion,
+		ConsoleVersion:    builtversion.Get().String(),
 	}
 
 	extensionProps := assets.WebConsoleExtensionProperties{

--- a/pkg/assets/apiserver/cmd/start.go
+++ b/pkg/assets/apiserver/cmd/start.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openshift/origin-web-console-server/pkg/apis/webconsole/validation"
 	webconsoleserver "github.com/openshift/origin-web-console-server/pkg/assets/apiserver"
 	"github.com/openshift/origin-web-console-server/pkg/origin-common/crypto"
+	builtversion "github.com/openshift/origin-web-console-server/pkg/version"
 )
 
 type WebConsoleServerOptions struct {
@@ -204,6 +205,7 @@ func (o WebConsoleServerOptions) RunWebConsoleServer(stopCh <-chan struct{}) err
 	if err != nil {
 		return err
 	}
+	glog.Infof("OpenShift Web Console Version: %s", builtversion.Get().String())
 	return server.GenericAPIServer.PrepareRun().Run(stopCh)
 }
 

--- a/pkg/assets/handlers.go
+++ b/pkg/assets/handlers.go
@@ -192,13 +192,15 @@ func addExtensionStylesheets(content []byte, extensionStylesheets []string) []by
 var versionTemplate = template.Must(template.New("webConsoleVersion").Parse(`
 window.OPENSHIFT_VERSION = {
   openshift: "{{ .OpenShiftVersion | js}}",
-  kubernetes: "{{ .KubernetesVersion | js}}"
+  kubernetes: "{{ .KubernetesVersion | js}}",
+  console: "{{ .ConsoleVersion | js }}"
 };
 `))
 
 type WebConsoleVersion struct {
 	KubernetesVersion string
 	OpenShiftVersion  string
+	ConsoleVersion    string
 }
 
 var extensionPropertiesTemplate = template.Must(template.New("webConsoleExtensionProperties").Parse(`


### PR DESCRIPTION
This lets us add the console version to the about page. Also logs version on start.

/assign @jwforres 
/cc @deads2k 