### PR TITLE
Revert "console autodetection"

### DIFF
--- a/pkg/assets/apiserver/cmd/start.go
+++ b/pkg/assets/apiserver/cmd/start.go
@@ -172,9 +172,6 @@ func (o WebConsoleServerOptions) Config() (*webconsoleserver.AssetServerConfig, 
 	if err := secureServingOptions.ApplyTo(&serverConfig.GenericConfig.Config); err != nil {
 		return nil, err
 	}
-	if err := genericapiserveroptions.NewCoreAPIOptions().ApplyTo(serverConfig.GenericConfig); err != nil {
-		return nil, err
-	}
 	if err := o.Audit.ApplyTo(&serverConfig.GenericConfig.Config); err != nil {
 		return nil, err
 	}
@@ -197,11 +194,7 @@ func (o WebConsoleServerOptions) RunWebConsoleServer(stopCh <-chan struct{}) err
 		return err
 	}
 
-	completedConfig, err := config.Complete()
-	if err != nil {
-		return err
-	}
-	server, err := completedConfig.New(genericapiserver.EmptyDelegate)
+	server, err := config.Complete().New(genericapiserver.EmptyDelegate)
 	if err != nil {
 		return err
 	}

--- a/pkg/assets/handlers.go
+++ b/pkg/assets/handlers.go
@@ -188,16 +188,12 @@ func addExtensionStylesheets(content []byte, extensionStylesheets []string) []by
 
 var versionTemplate = template.Must(template.New("webConsoleVersion").Parse(`
 window.OPENSHIFT_VERSION = {
-  openshift: "{{ .OpenShiftVersion | js}}",
-  kubernetes: "{{ .KubernetesVersion | js}}",
   console: "{{ .ConsoleVersion | js }}"
 };
 `))
 
 type WebConsoleVersion struct {
-	KubernetesVersion string
-	OpenShiftVersion  string
-	ConsoleVersion    string
+	ConsoleVersion string
 }
 
 var extensionPropertiesTemplate = template.Must(template.New("webConsoleExtensionProperties").Parse(`


### PR DESCRIPTION
This reverts commit 6555bedcd7d182f219cf9a605d41ce07a24a8ce3.

/assign @deads2k 

Requires https://github.com/openshift/origin-web-catalog/pull/642

Follow on openshift-ansible and origin PRs will remove the console RBAC template, which isn't needed anymore.