### PR TITLE
init.sh: Fix of absolute path resolution

### DIFF
--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -31,7 +31,7 @@ readonly -f os::util::absolute_path
 
 # find the absolute path to the root of the Origin source tree
 init_source="$( dirname "${BASH_SOURCE}" )/../.."
-OS_ROOT="$( os::util::absolute_path "${init_source}" )"
+OS_ROOT="$( realpath "${init_source}" )"
 export OS_ROOT
 cd "${OS_ROOT}"
 


### PR DESCRIPTION
Problems:
* readlink used in os::util::absolute_path actually reads content
of symlink record. If the symlink is relative, it's content is path
relative to symlink's parent. Code of os::util::absolute_path interprets
it as if it were path relative to symlink itself.
* symlink to symlink case is not handled.

Solution:
`realpath`. Both realpath and readlink are distributed in the same package -
coreutils - in CentOS and Fedora.